### PR TITLE
[Exploration] Enrich the return value of DSL handlers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -143,3 +143,4 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	lukechampine.com/blake3 v1.1.7 // indirect
 )
+

--- a/pkg/bcb/bcbdsl/events.go
+++ b/pkg/bcb/bcbdsl/events.go
@@ -44,55 +44,55 @@ func Deliver(m dsl.Module, dest t.ModuleID, data []byte) {
 
 // Module-specific dsl functions for processing events.
 
-func UponEvent[EvWrapper bcbpb.Event_TypeWrapper[Ev], Ev any](m dsl.Module, handler func(ev *Ev) error) {
-	dsl.UponEvent[*eventpb.Event_Bcb](m, func(ev *bcbpb.Event) error {
+func UponEvent[EvWrapper bcbpb.Event_TypeWrapper[Ev], Ev any](m dsl.Module, handler func(ev *Ev) dsl.Result) {
+	dsl.UponEvent[*eventpb.Event_Bcb](m, func(ev *bcbpb.Event) dsl.Result {
 		evWrapper, ok := ev.Type.(EvWrapper)
 		if !ok {
-			return nil
+			return dsl.NoMatch()
 		}
 		return handler(evWrapper.Unwrap())
 	})
 }
 
-func UponBroadcastRequest(m dsl.Module, handler func(data []byte) error) {
-	UponEvent[*bcbpb.Event_Request](m, func(ev *bcbpb.BroadcastRequest) error {
+func UponBroadcastRequest(m dsl.Module, handler func(data []byte) dsl.Result) {
+	UponEvent[*bcbpb.Event_Request](m, func(ev *bcbpb.BroadcastRequest) dsl.Result {
 		return handler(ev.Data)
 	})
 }
 
-func UponDeliver(m dsl.Module, handler func(data []byte) error) {
-	UponEvent[*bcbpb.Event_Deliver](m, func(ev *bcbpb.Deliver) error {
+func UponDeliver(m dsl.Module, handler func(data []byte) dsl.Result) {
+	UponEvent[*bcbpb.Event_Deliver](m, func(ev *bcbpb.Deliver) dsl.Result {
 		return handler(ev.Data)
 	})
 }
 
-func UponBCBMessageReceived(m dsl.Module, handler func(from t.NodeID, msg *bcbpb.Message) error) {
-	dsl.UponMessageReceived(m, func(from t.NodeID, msg *messagepb.Message) error {
+func UponBCBMessageReceived(m dsl.Module, handler func(from t.NodeID, msg *bcbpb.Message) dsl.Result) {
+	dsl.UponMessageReceived(m, func(from t.NodeID, msg *messagepb.Message) dsl.Result {
 		cbMsgWrapper, ok := msg.Type.(*messagepb.Message_Bcb)
 		if !ok {
-			return nil
+			return dsl.NoMatch()
 		}
 
 		return handler(from, cbMsgWrapper.Bcb)
 	})
 }
 
-func UponStartMessageReceived(m dsl.Module, handler func(from t.NodeID, data []byte) error) {
-	UponBCBMessageReceived(m, func(from t.NodeID, msg *bcbpb.Message) error {
+func UponStartMessageReceived(m dsl.Module, handler func(from t.NodeID, data []byte) dsl.Result) {
+	UponBCBMessageReceived(m, func(from t.NodeID, msg *bcbpb.Message) dsl.Result {
 		startMsgWrapper, ok := msg.Type.(*bcbpb.Message_StartMessage)
 		if !ok {
-			return nil
+			return dsl.NoMatch()
 		}
 
 		return handler(from, startMsgWrapper.StartMessage.Data)
 	})
 }
 
-func UponEchoMessageReceived(m dsl.Module, handler func(from t.NodeID, signature []byte) error) {
-	UponBCBMessageReceived(m, func(from t.NodeID, msg *bcbpb.Message) error {
+func UponEchoMessageReceived(m dsl.Module, handler func(from t.NodeID, signature []byte) dsl.Result) {
+	UponBCBMessageReceived(m, func(from t.NodeID, msg *bcbpb.Message) dsl.Result {
 		echoMsgWrapper, ok := msg.Type.(*bcbpb.Message_EchoMessage)
 		if !ok {
-			return nil
+			return dsl.NoMatch()
 		}
 
 		return handler(from, echoMsgWrapper.EchoMessage.Signature)
@@ -101,12 +101,12 @@ func UponEchoMessageReceived(m dsl.Module, handler func(from t.NodeID, signature
 
 func UponFinalMessageReceived(
 	m dsl.Module,
-	handler func(from t.NodeID, data []byte, signers []t.NodeID, signatures [][]byte) error,
+	handler func(from t.NodeID, data []byte, signers []t.NodeID, signatures [][]byte) dsl.Result,
 ) {
-	UponBCBMessageReceived(m, func(from t.NodeID, msg *bcbpb.Message) error {
+	UponBCBMessageReceived(m, func(from t.NodeID, msg *bcbpb.Message) dsl.Result {
 		finalMsgWrapper, ok := msg.Type.(*bcbpb.Message_FinalMessage)
 		if !ok {
-			return nil
+			return dsl.NoMatch()
 		}
 
 		finalMsg := finalMsgWrapper.FinalMessage

--- a/pkg/dsl/result.go
+++ b/pkg/dsl/result.go
@@ -1,0 +1,64 @@
+package dsl
+
+import (
+	"errors"
+	"fmt"
+)
+
+type Result struct {
+	err     error
+	matched bool
+	repeat  bool
+}
+
+func (r Result) Err() error {
+	return r.err
+}
+
+func (r Result) Matched() bool {
+	return r.matched
+}
+
+func (r Result) Repeat() bool {
+	return r.repeat
+}
+
+func FromError(err error) Result {
+	return Result{
+		err:     err,
+		matched: true,
+		repeat:  false,
+	}
+}
+
+func Error(s string) Result {
+	return FromError(errors.New(s))
+}
+
+func Errorf(format string, args ...any) Result {
+	return FromError(fmt.Errorf(format, args...))
+}
+
+func NoMatch() Result {
+	return Result{
+		err:     nil,
+		matched: false,
+		repeat:  true,
+	}
+}
+
+func OK() Result {
+	return Result{
+		err:     nil,
+		matched: true,
+		repeat:  true,
+	}
+}
+
+func DontRepeat() Result {
+	return Result{
+		err:     nil,
+		matched: true,
+		repeat:  false,
+	}
+}


### PR DESCRIPTION
Through the return value, the handler can:
1) return an error
2) pass the information that the event doesn't match the handler
3) inform the dsl core that the handler should be unregistered
   and should never be repeated again.

The main motivation behind this is to dynamically register
handlers within other handlers (to avoid running out of memory,
this implies the need to unregister handlers).

However, the problem is that dynamically creating a large number
of handlers would not play well with the current appoach of
trying "searching" for the right handler by trying all handlers
for the event type. Indeed, the linear search may be too slow and
wasteful.

There was also a problem with the NoMatch() return value. The
problem is that it is not always trivial to choose between
NoMatch() and OK(). Moreover, sometimes it can lead to potential
vulnerabilities: e.g., if there is an incoming nonsense message
and all message handlers return NoMatch(), the module may return
an error and crash.